### PR TITLE
Fix/youtube download

### DIFF
--- a/backend/core/constants.py
+++ b/backend/core/constants.py
@@ -24,7 +24,8 @@ DOWNLOADED_TRANSCRIPT_PATH = f"{DOWNLOADED_TRANSCRIPT_DIR}/%(title)s.%(ext)s"
 # Constants for video and audio formats
 VIDEO_FORMAT = 'bestvideo+bestaudio/best/mp4'
 AUDIO_FORMAT = 'mp3/bestaudio'
-LANGUAGE = 'ja'  # Default language for transcription
+LANGUAGE = ['ja', 'en']  # Default language for transcription
+TRANSCRIPT_EXT = "json"
 
 VIDEO_OPTION = {
     'format': VIDEO_FORMAT,
@@ -34,15 +35,6 @@ VIDEO_OPTION = {
 AUDIO_OPTION = {
     'format': AUDIO_FORMAT,
     'outtmpl': DOWNLOADED_AUDIO_PATH,
-}
-
-TRANSCRIPT_OPTION = {
-    'writesubtitles': True,
-    'subtitleslangs': ['ja'],  # Japanese subtitles
-    'outtmpl': DOWNLOADED_TRANSCRIPT_PATH,
-    'skip_download': True,  # Skip downloading the video
-    'writeautomaticsub': True,  # Download automatic subtitles if available
-    'subtitlesformat': 'vtt',  # Use VTT format for subtitles
 }
 
 

--- a/backend/tests/test_download_services.py
+++ b/backend/tests/test_download_services.py
@@ -2,9 +2,10 @@ from pathlib import Path
 import pytest
 from unittest.mock import patch, MagicMock
 from backend.services.youtube_download import VideoDownloadService, AudioDownloadService, TranscriptDownloadService
-from backend.core.constants import AUDIO_FORMAT, DOWNLOADED_AUDIO_PATH, DOWNLOADED_VIDEO_PATH, LANGUAGE, TRANSCRIPT_OPTION, VIDEO_FORMAT
+from backend.core.constants import AUDIO_FORMAT, DOWNLOADED_AUDIO_PATH, DOWNLOADED_TRANSCRIPT_PATH, DOWNLOADED_VIDEO_PATH, TRANSCRIPT_EXT, VIDEO_FORMAT
 
 URL = "https://www.youtube.com/watch?v=test123"
+TITLE = "Fake / title"
 
 
 @pytest.mark.parametrize(
@@ -14,21 +15,26 @@ URL = "https://www.youtube.com/watch?v=test123"
         (AudioDownloadService, AUDIO_FORMAT, DOWNLOADED_AUDIO_PATH, 'mp3'),
     ]
 )
+@patch("backend.services.youtube_download.os.rename", return_value=None)
 @patch("backend.services.youtube_download.os.path.exists", return_value=True)
 @patch("backend.services.youtube_download.YoutubeDL")
-def test_download_service(mock_youtubedl, _, service_class, expected_format, expected_outtmpl, expected_ext):
+def test_download_service(mock_youtubedl, _, mock_rename, service_class, expected_format, expected_outtmpl, expected_ext):
+    service = service_class()
+
     mock_instance = MagicMock()
     mock_youtubedl.return_value.__enter__.return_value = mock_instance
 
+    sanitized_title = "Fake _ title"
     # Mock extract_info to return a dummy info dict with requested_downloads
     dummy_info = {
+        "title": sanitized_title,
+        "ext": expected_ext,
         "requested_downloads": [
-            {"filename": f"{expected_outtmpl.replace('%(title)s', 'Test Video').replace('%(ext)s', expected_ext)}"}
+            {"filename": f"{expected_outtmpl.replace('%(title)s', sanitized_title).replace('%(ext)s', expected_ext)}"}
         ]
     }
     mock_instance.extract_info.return_value = dummy_info
 
-    service = service_class()
     result = service.download(URL)
 
     expected_path = dummy_info["requested_downloads"][0]["filename"]
@@ -40,31 +46,22 @@ def test_download_service(mock_youtubedl, _, service_class, expected_format, exp
     mock_instance.extract_info.assert_called_once_with(URL, download=True)
 
 
-@patch("backend.services.youtube_download.os.path.exists", return_value=True)
+@patch("backend.services.youtube_download.YouTubeTranscriptApi")
 @patch("backend.services.youtube_download.YoutubeDL")
-def test_transcript_download_service(mock_youtubedl, _):
-    mock_instance = mock_youtubedl.return_value.__enter__.return_value
-
-    # Mock the info dict returned by extract_info
-    dummy_info = {
-        "id": "test123",
-        "title": "Test Video",
-        "requested_subtitles": {
-            LANGUAGE: {"ext": "vtt", "url": "https://example.com/sub.vtt"}
-        }
-    }
-    mock_instance.extract_info.return_value = dummy_info
-
+def test_transcript_download_service(mock_youtubedl, mock_youtube_transcript_api):
     service = TranscriptDownloadService()
+
+    sanitized_title = "Fake _ title"
+    fake_transcript_data = {"text": "hello world"}
+
+    mock_youtubedl.return_value.__enter__.return_value.extract_info.return_value = {
+        "title": sanitized_title}
+    mock_youtube_transcript_api.return_value.fetch.return_value.to_raw_data.return_value = fake_transcript_data
+
     result = service.download(URL)
 
     # Build the expected path
-    expected_base = Path(
-        mock_instance.prepare_filename.return_value or f"Test Video.mp4").with_suffix("")
-    expected_path = str(expected_base.with_suffix(f".{LANGUAGE}.vtt"))
+    expected_path = DOWNLOADED_TRANSCRIPT_PATH % {
+        "title": sanitized_title, "ext": TRANSCRIPT_EXT}
 
     assert result == expected_path
-
-    # Assert YoutubeDL was instantiated with the correct options
-    mock_youtubedl.assert_called_once_with(TRANSCRIPT_OPTION)
-    mock_instance.extract_info.assert_called_once_with(URL, download=True)


### PR DESCRIPTION
### What's changed
- BaseDownloadService. _download: Added sanitization of video title to remove special characters. Removed ```path_extractor``` since both video and audio download services share that same logic to extract filename
- BaseDownloadService._sanitize_filename: To sanitize video title to remove special characters
- VideoDownloadService and AudioDownloadService download: Removed ```path_extractor``` variable when calling ```_download ```
- TranscriptDownloadService.download: Changed to library ```YouTubeTranscriptApi``` to download transcripts

### Why
- Special characters (such as ```\/*?:"<>|```) in youtube title breaks file path. Hence sanitization of video title is added.
- Changed to use ```YouTubeTranscriptApi``` to download transcripts because when using ```yt_dlp``` to download transcripts, youtube blocked the access to download after too many requests.
- Changed the ```_download``` method to exclude the variable ```path_extractor``` since both video and audio download services use the same logic to extract filename

### How it works
- After downloading the media (video, audio or transcripts), special characters in the video title are replaced with ```_```
- ```TranscriptDownloadService``` uses ```YouTubeTranscriptApi``` to download transcripts. However, the library does not return video title. Hence, ```yt-dlp``` is used to fetch video title.

### Testing
- Refactored unit tests for ```VideoDownloadService```, ```AudioDownloadService``` and ```TranscriptDownloadService```
- Verified that video title with special characters are correctly sanitized.