### PR TITLE
Fix/highlight detection

### DIFF
--- a/backend/core/constants.py
+++ b/backend/core/constants.py
@@ -12,6 +12,7 @@ END = "end"
 TEXT = "text"
 HIGHLIGHT_SCORE = "highlight_score"
 REASON = "reason"
+DURATION = "duration"
 
 # These paths are used to store downloaded videos and audios.
 DOWNLOADED_VIDEO_DIR = "./backend/download/downloaded_videos"

--- a/backend/tests/test_transcript_parser_service.py
+++ b/backend/tests/test_transcript_parser_service.py
@@ -3,56 +3,41 @@ from backend.services.transcript_parser import TranscriptParser
 from textwrap import dedent
 
 
-def test_parse_webvtt():
+def test_parse_transcripts():
     # Sample VTT content
-    vtt_content = """
-    WEBVTT
-    Kind: captions
-    Language: ja
-
-    00:00:00.160 --> 00:00:04.870 align:start position:0%
-    
-    いやあ<00:00:00.480><c>、</c><00:00:00.680><c>まあ</c><00:00:01.520><c>昨日</c><00:00:02.240><c>は</c><00:00:02.440><c>ね</c><00:00:02.679><c>、</c><00:00:03.639><c>大変</c><00:00:03.959><c>な</c><00:00:04.080><c>1</c><00:00:04.319><c>日</c><00:00:04.520><c>だっ</c><00:00:04.759><c>た</c>
-
-    00:00:04.870 --> 00:00:04.880 align:start position:0%
-    いやあ、まあ昨日はね、大変な1日だった
-    
-
-    00:00:04.880 --> 00:00:07.950 align:start position:0%
-    いやあ、まあ昨日はね、大変な1日だった
-    。<00:00:05.279><c>もう</c><00:00:05.560><c>それ</c><00:00:05.799><c>以外</c><00:00:06.120><c>の</c><00:00:06.279><c>こと</c><00:00:06.480><c>が</c><00:00:06.680><c>何</c><00:00:06.879><c>も</c><00:00:07.120><c>考え</c><00:00:07.439><c>られ</c><00:00:07.799><c>な</c>
-
-    00:00:07.950 --> 00:00:07.960 align:start position:0%
-    。もうそれ以外のことが何も考えられな
-    
-
-    00:00:07.960 --> 00:00:12.749 align:start position:0%
-    。もうそれ以外のことが何も考えられな
-    すぎ<00:00:08.200><c>て</c><00:00:09.080><c>1</c><00:00:09.320><c>日</c><00:00:10.559><c>なんか</c><00:00:11.480><c>ぼーっと</c><00:00:11.920><c>し</c><00:00:12.040><c>て</c><00:00:12.120><c>過ごし</c><00:00:12.480><c>て</c><00:00:12.599><c>た</c>
-
-    00:00:12.749 --> 00:00:12.759 align:start position:0%
-    すぎて1日なんかぼーっとして過ごしてた
-    
-
-    00:00:12.759 --> 00:00:16.230 align:start position:0%
-    すぎて1日なんかぼーっとして過ごしてた
-    """
+    json_content = [
+        {
+            "text": "A",
+            "start": 0.0,
+            "duration": 5
+        },
+        {
+            "text": "B",
+            "start": 5.0,
+            "duration": 40.0
+        },
+        {
+            "text": "C",
+            "start": 90.0,
+            "duration": 3
+        },
+    ]
 
     # Expected parsed entries
     expected_entries = [
-        {START: "00:00:04.880", END: "00:00:07.950",
-            TEXT: "いやあ、まあ昨日はね、大変な1日だった"},
-        {START: "00:00:07.960", END: "00:00:12.749",
-            TEXT: "。もうそれ以外のことが何も考えられな"},
-        {START: "00:00:12.759", END: "00:00:16.230",
-            TEXT: "すぎて1日なんかぼーっとして過ごしてた"}
+        {START: "00:00:00.000", END: "00:00:05.000",
+            TEXT: "A"},
+        {START: "00:00:05.000", END: "00:01:30.000",
+            TEXT: "B"},
+        {START: "00:01:30.000", END: "00:01:33.000",
+            TEXT: "C"}
     ]
 
     # Create an instance of the TranscriptParserService
     parser_service = TranscriptParser()
 
     # Parse the VTT content
-    parsed_entries = parser_service.parse_webvtt(dedent(vtt_content))
+    parsed_entries = parser_service._parse_transcripts(json_content)
 
     # Assert that the parsed entries match the expected entries
     assert parsed_entries == expected_entries
@@ -83,7 +68,7 @@ def test_aggregate_transcripts():
     parser_service = TranscriptParser()
 
     # Aggregate the transcripts
-    aggregated_entries = parser_service.aggregate_transcripts(parsed_entries)
+    aggregated_entries = parser_service._aggregate_transcripts(parsed_entries)
 
     # Assert that the aggregated entries match the expected entries
     assert aggregated_entries == expected_aggregated


### PR DESCRIPTION
### What's changed
- TranscriptParser.parse: Take transcript file path as input
- TranscriptParser._extract_json: Extract json from transcript file into list of dicts
- TranscriptParser._parse_transcripts: Instead of using regex to determine start, end and text, extract those variables from the list of dicts
- TranscriptParser._format_seconds: Format seconds into timestamp similar to the timestamps used in vtt

### Why
- Instead of reading file at a higher level, filepath can be directly passed from the output of ```TranscriptDownloadService.download``` directly into ```TranscriptParser.parse```
- Original vtt transcripts have different format than the one in json, hence ```TranscriptParser._parse_transcripts``` is refactored accordingly

### How it works
- json file is read by ```TranscriptParser._extract_json``` and a list of dicts is returned
- ```TranscriptParser._parse_transcripts``` parses into transcripts that can be used downstream

### Testing
- Unit test for _parse_transcripts is refactored
- Verified that list of dicts are correctly parsed into the desired format