### PR TITLE
Fix/ai rpm limit

### DIFF
--- a/backend/core/constants.py
+++ b/backend/core/constants.py
@@ -6,6 +6,11 @@ MAX_SCORE = 10
 MIN_SCORE = 0
 THRESHOLD_SCORE = 7
 
+# AI request
+AI_REQUEST_PER_MINUTE_LIMIT = 15
+AI_REQUEST_BUFFER_SECONDS = 10
+SLEEP_TIME_BEFORE_RETRY_SECONDS = 1
+
 # Highlight
 START = "start"
 END = "end"
@@ -38,7 +43,9 @@ AUDIO_OPTION = {
     'outtmpl': DOWNLOADED_AUDIO_PATH,
 }
 
-
+# AI
+AI_RESPONSE_PRECEDING_STRING_FORMAT = r"^```(?:json)?\s*"
+AI_RESPONSE_SUCCEDING_STRING_FORMAT = r"\s*```$"
 HIGHLIGHT_DETECTION_PROMPT = f"""
 You are a livestream highlight detector.
 

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -1,3 +1,4 @@
 import os
 
 GOOGLE_AI_API_KEY = os.getenv('GOOGLE_AI_API_KEY')
+GOOGLE_AI_MODEL = os.getenv('GOOGLE_AI_MODEL')


### PR DESCRIPTION
### What's changed
- HighlightDetectionService.score_transcripts: Watches request count/minute sent to ensure it does not go over the limit defined by api provider (Google in my case)

### Why
- Google gemini api has a rate limit for free tier users. I use ```gemini-2.5-flash-lite``` that has a limit of 15 rpm. 
<img width="2100" height="912" alt="Screenshot 2025-08-30 at 2 48 49 PM" src="https://github.com/user-attachments/assets/190bdf07-cd4a-4641-a39b-48a2b0b1440d" />

### How it works
- For every ```15``` requests, check if ```1``` minute has passed since the first request (within the ```15``` requests).
- Sleep in ```1``` second increment until ```1``` minute and ```10``` seconds has passed. The additional 10 seconds is there for a little bit of buffer and a bit of good luck 😉.

### Testing
No test added