### PR TITLE
Fix/ Highlight detection unit test

### DIFF
--- a/backend/tests/test_highlight_detection_service.py
+++ b/backend/tests/test_highlight_detection_service.py
@@ -41,7 +41,8 @@ def test_score_transcripts(client_mock):
     assert scored_transcripts[1][REASON] == "mock reason"
 
 
-def test_detect_highlights():
+@patch("backend.services.highlight_detection.genai.Client")
+def test_detect_highlights(_):
     service = HighlightDetectionService()
 
     transcripts = [
@@ -83,7 +84,8 @@ def test_detect_highlights():
     assert highlights[1][REASON] == "Very interesting"
 
 
-def test_aggregate_highlights():
+@patch("backend.services.highlight_detection.genai.Client")
+def test_aggregate_highlights(_):
     service = HighlightDetectionService()
 
     highlights = [


### PR DESCRIPTION
### What's changed
- test_detect_highlights, test_aggregate_highlights: Mock genai Client

### Why
- Instead of running unit tests one by one in VS Code using the green run test button, I wanted to run all of the test in one go. So I decided to run ```pytest``` from the terminal.
- When running ```pytest``` in terminal, the ```Client``` cannot be generated in the ```HighlightDetectionService``` constructor. Somehow when running this test in VS Code, the ```Client``` can be generated without any problem but not in ```pytest``` when running in terminal. Hence, the patch is added into the unit tests so that ```pytest``` can be run in the terminal.

### How it works

### Testing