### PR TITLE
fix: Added origins to allow connection from frontend

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 from backend.routers.router import router
+from fastapi.middleware.cors import CORSMiddleware
 
 
 app = FastAPI(
@@ -9,6 +10,17 @@ app = FastAPI(
 
 app.include_router(router, prefix="/api/v1")
 
+origins = [
+    "http://localhost:5173",
+]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 # For demonstration purposes
 if __name__ == "__main__":


### PR DESCRIPTION
### What's changed
- main: Add origins to be allowed to connect to backend

### Why
- To enable connection from frontend (and only frontend) to connect to backend

### How it works
- Fastapi middleware will permit or deny requests made from different origin based on the defined origins

### Testing
No test added